### PR TITLE
Add API_URL env var usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ php -S localhost:8000
 
 4. **Visit** `http://localhost:8000` in your browser
 
+### Environment Variables
+
+Create a `.env` file based on `.env.example` and set `VITE_API_URL` to the base
+URL of your backend API:
+
+```bash
+cp .env.example .env
+# edit .env and change the URL if needed
+```
+
 ## 📁 Project Structure
 
 ```

--- a/src/hooks/useContactForm.ts
+++ b/src/hooks/useContactForm.ts
@@ -4,6 +4,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { contactFormSchema, type ContactFormData, sanitizeInput, createRateLimiter } from '@/lib/validation';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 // Rate limiter: max 3 submissions per 5 minutes per email
 const rateLimiter = createRateLimiter(3, 5 * 60 * 1000);
 

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -9,6 +9,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const AdminPage = () => {
   const navigate = useNavigate();
   const { user, userRole, loading, signOut } = useAuth();

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,6 +11,8 @@ import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 const LoginPage = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -64,7 +66,7 @@ const LoginPage = () => {
 
     try {
       if (isSignUp) {
-        const redirectUrl = `${window.location.origin}/`;
+        const redirectUrl = `${API_URL}/`;
         
         const { data, error } = await supabase.auth.signUp({
           email: email.toLowerCase().trim(),


### PR DESCRIPTION
## Summary
- add `.env.example` with VITE_API_URL
- reference `import.meta.env.VITE_API_URL` in contact hook and admin/login pages
- document environment variables in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68403ef49fa4832cb32878609a5e35a6