### PR TITLE
Update contact form validation rules

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 const Contact = () => {
   const { currentLanguage, t } = useTranslation();
-  const { formData, errors, handleChange, handleSubmit, isSubmitting, hasErrors } = useContactForm();
+  const { formData, errors, handleChange, handleSubmit, isSubmitting, isFormValid } = useContactForm();
 
   return (
     <section id="contact" className="py-16 bg-muted/30">
@@ -95,7 +95,7 @@ const Contact = () => {
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="email">{t('contact_form_email')} *</Label>
+                  <Label htmlFor="email">{t('contact_form_email')}</Label>
                   <Input
                     id="email"
                     name="email"
@@ -105,7 +105,6 @@ const Contact = () => {
                     onChange={handleChange}
                     className={errors.email ? 'border-red-500' : ''}
                     disabled={isSubmitting}
-                    required
                     maxLength={254}
                   />
                   {errors.email && (
@@ -114,7 +113,7 @@ const Contact = () => {
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="phone">{t('contact_form_phone')}</Label>
+                  <Label htmlFor="phone">{t('contact_form_phone')} *</Label>
                   <Input
                     id="phone"
                     name="phone"
@@ -124,6 +123,7 @@ const Contact = () => {
                     onChange={handleChange}
                     className={errors.phone ? 'border-red-500' : ''}
                     disabled={isSubmitting}
+                    required
                     maxLength={20}
                   />
                   {errors.phone && (
@@ -154,10 +154,10 @@ const Contact = () => {
                   </div>
                 </div>
 
-                <Button 
-                  type="submit" 
-                  className="w-full" 
-                  disabled={isSubmitting || hasErrors}
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={isSubmitting || !isFormValid}
                 >
                   <Send className="h-4 w-4 mr-2" />
                   {isSubmitting ? t('contact_form_sending') : t('contact_form_send')}

--- a/src/hooks/useContactForm.ts
+++ b/src/hooks/useContactForm.ts
@@ -69,8 +69,8 @@ export const useContactForm = () => {
 
       const sanitizedData = {
         name: sanitizeInput(validationResult.data.name).trim(),
-        email: validationResult.data.email.trim(),
-        phone: validationResult.data.phone ? sanitizeInput(validationResult.data.phone).trim() : null,
+        email: validationResult.data.email ? validationResult.data.email.trim() : '',
+        phone: sanitizeInput(validationResult.data.phone).trim(),
         message: sanitizeInput(validationResult.data.message).trim()
       };
 
@@ -101,12 +101,20 @@ export const useContactForm = () => {
     }
   };
 
+  const hasErrors = Object.values(errors).some(error => error !== undefined);
+  const isFormValid =
+    !hasErrors &&
+    formData.name.trim() !== '' &&
+    formData.phone.trim() !== '' &&
+    formData.message.trim() !== '';
+
   return {
     formData,
     errors,
     handleChange,
     handleSubmit,
     isSubmitting,
-    hasErrors: Object.values(errors).some(error => error !== undefined)
+    hasErrors,
+    isFormValid
   };
 };

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -6,19 +6,22 @@ export const contactFormSchema = z.object({
     .min(2, 'Name must be at least 2 characters')
     .max(100, 'Name must be less than 100 characters')
     .regex(/^[a-zA-ZšđčćžŠĐČĆŽ\s-']+$/, 'Name contains invalid characters'),
-  email: z.string()
-    .email('Please enter a valid email address')
-    .max(254, 'Email is too long')
-    .toLowerCase(),
-  phone: z.string()
-    .optional()
+  email: z.preprocess(
+    (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+    z
+      .string()
+      .email('Unesite važeću email adresu')
+      .max(254, 'Email je predugačak')
+      .toLowerCase()
+      .optional()
+  ),
+  phone: z
+    .string({ required_error: 'Telefon je obavezan' })
     .refine((val) => {
-      if (!val) return true; // Optional field
-      // Allow international phone formats
       const phoneRegex = /^\+?[1-9]\d{0,15}$/;
       const cleanPhone = val.replace(/[\s-()]/g, '');
       return phoneRegex.test(cleanPhone) && cleanPhone.length >= 8 && cleanPhone.length <= 16;
-    }, 'Please enter a valid phone number'),
+    }, 'Unesite ispravan broj telefona'),
   message: z.string()
     .min(10, 'Message must be at least 10 characters')
     .max(2000, 'Message must be less than 2000 characters')


### PR DESCRIPTION
## Summary
- adjust contact form required fields and button state
- update contact form hook logic
- update Zod schema for phone and email

## Testing
- `npm run lint`
- `npm run build`
- `npx tsx <<'EOF'
import { contactFormSchema } from './src/lib/validation.ts';
console.log('Test1', contactFormSchema.safeParse({name:'John', email:'', phone:'12345678', message:'Hello there'}).success);
console.log('Test2', contactFormSchema.safeParse({name:'John', email:'', phone:'', message:'Hello there'}).success);
console.log('Test3', contactFormSchema.safeParse({name:'John', email:'j@e.com', phone:'12345678', message:'Hello there'}).success);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68406379bc1c832c946f56d4d94b1a92