### PR TITLE
Add contact messages page and API

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -47,6 +47,16 @@ app.post("/contact", async (req, res) => {
   }
 });
 
+app.get("/contact", async (req, res) => {
+  try {
+    const messages = await prisma.contactMessage.findMany();
+    res.json(messages);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to fetch messages" });
+  }
+});
+
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Suspense, lazy } from "react";
 
 const AdminPage = lazy(() => import("./pages/AdminPage"));
 const LoginPage = lazy(() => import("./pages/LoginPage"));
+const PristiglePoruke = lazy(() => import("./pages/PristiglePoruke"));
 import { TranslationProvider } from "@/hooks/useTranslation";
 
 const queryClient = new QueryClient();
@@ -24,6 +25,7 @@ const App = () => (
               <Route path="/" element={<WebFokusHome />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/admin" element={<AdminPage />} />
+              <Route path="/pristigleporuke" element={<PristiglePoruke />} />
             </Routes>
           </Suspense>
         </BrowserRouter>

--- a/src/pages/PristiglePoruke.tsx
+++ b/src/pages/PristiglePoruke.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+interface ContactMessage {
+  id: number;
+  name: string;
+  email: string | null;
+  phone?: string | null;
+  message: string;
+  createdAt: string;
+}
+
+const API_URL = `${import.meta.env.VITE_API_URL}/contact`;
+
+const PristiglePoruke = () => {
+  const navigate = useNavigate();
+  const [authorized, setAuthorized] = useState(false);
+  const [messages, setMessages] = useState<ContactMessage[]>([]);
+
+  useEffect(() => {
+    const pwd = window.prompt('Enter password');
+    if (pwd === 'tajna123') {
+      setAuthorized(true);
+    } else {
+      navigate('/');
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!authorized) return;
+    const fetchMessages = async () => {
+      try {
+        const res = await fetch(API_URL);
+        if (!res.ok) throw new Error('Failed to fetch');
+        const data = await res.json();
+        setMessages(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchMessages();
+  }, [authorized]);
+
+  if (!authorized) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-8">
+      <div className="max-w-4xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle>Pristigle poruke</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {messages.length === 0 ? (
+              <p className="text-muted-foreground text-center">No messages</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Phone</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Message</TableHead>
+                    <TableHead>Date</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {messages.map((m) => (
+                    <TableRow key={m.id}>
+                      <TableCell>{m.name}</TableCell>
+                      <TableCell>{m.phone || '-'}</TableCell>
+                      <TableCell>{m.email || '-'}</TableCell>
+                      <TableCell className="max-w-xs whitespace-pre-wrap">{m.message}</TableCell>
+                      <TableCell>{new Date(m.createdAt).toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default PristiglePoruke;
+


### PR DESCRIPTION
## Summary
- create `/pristigleporuke` page to view contact messages
- wire the new page into router
- expose `GET /contact` endpoint in backend for fetching messages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68406df96dfc832ca2523f8a4efbb384