### PR TITLE
Enhance SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     <meta name="author" content="Web Fokus" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://webfokus.ba" />
+    <link rel="alternate" hreflang="bs" href="https://webfokus.ba/" />
+    <link rel="alternate" hreflang="en" href="https://webfokus.ba/en" />
     
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Web Fokus - Brzi i povoljni web-sajtovi za mali biznis" />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://webfokus.ba/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://webfokus.ba/login</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
+  </url>
+</urlset>

--- a/src/components/PortfolioModal.tsx
+++ b/src/components/PortfolioModal.tsx
@@ -29,7 +29,7 @@ const PortfolioModal: React.FC<PortfolioModalProps> = ({ project, onClose }) => 
         <div className="relative">
           <img
             src={project.image}
-            alt={project.title}
+            alt={`Screenshot of ${project.title}`}
             className="w-full h-64 object-cover rounded-t-lg"
             width={800}
             height={256}

--- a/src/components/PortfolioOptimized.tsx
+++ b/src/components/PortfolioOptimized.tsx
@@ -104,7 +104,7 @@ const PortfolioOptimized = () => {
               <div className="relative overflow-hidden">
                 <img
                   src={project.image}
-                  alt={`${project.title} - ${currentLanguage === 'bs' ? 'Web Fokus portfolio projekat' : 'Web Fokus portfolio project'}`}
+                  alt={`Screenshot ${currentLanguage === 'bs' ? 'sajta' : 'of'} ${project.title}`}
                   className="w-full h-48 object-cover transition-transform duration-300 group-hover:scale-105"
                   loading="lazy"
                   width="400"

--- a/src/hooks/useSEO.ts
+++ b/src/hooks/useSEO.ts
@@ -8,6 +8,7 @@ interface SEOData {
   ogTitle?: string;
   ogDescription?: string;
   ogImage?: string;
+  ogUrl?: string;
   canonical?: string;
   lang?: string;
 }
@@ -39,11 +40,13 @@ export const useSEO = (seoData: SEOData) => {
     updateMetaTag('og:title', seoData.ogTitle || seoData.title, true);
     updateMetaTag('og:description', seoData.ogDescription || seoData.description, true);
     if (seoData.ogImage) updateMetaTag('og:image', seoData.ogImage, true);
+    if (seoData.ogUrl) updateMetaTag('og:url', seoData.ogUrl, true);
     
     // Twitter tags
     updateMetaTag('twitter:title', seoData.ogTitle || seoData.title);
     updateMetaTag('twitter:description', seoData.ogDescription || seoData.description);
     if (seoData.ogImage) updateMetaTag('twitter:image', seoData.ogImage);
+    if (seoData.ogUrl) updateMetaTag('twitter:url', seoData.ogUrl);
     
     // Canonical URL
     if (seoData.canonical) {

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -6,12 +6,39 @@ import { ArrowLeft } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
+import { useSEO } from '@/hooks/useSEO';
+import { useTranslation } from '@/hooks/useTranslation';
 
 const API_URL = `${import.meta.env.VITE_API_URL}/users`;
 
 const AdminPage = () => {
   const navigate = useNavigate();
   const { user, loading, signOut } = useAuth();
+  const { currentLanguage } = useTranslation();
+
+  useSEO({
+    title:
+      currentLanguage === 'bs'
+        ? 'Admin panel - Web Fokus'
+        : 'Admin Dashboard - Web Fokus',
+    description:
+      currentLanguage === 'bs'
+        ? 'Administracija korisnika i poruka na Web Fokus sajtu.'
+        : 'Administration area for managing users and messages on the Web Fokus site.',
+    keywords: 'web fokus admin,panel',
+    ogTitle:
+      currentLanguage === 'bs'
+        ? 'Admin panel - Web Fokus'
+        : 'Admin Dashboard - Web Fokus',
+    ogDescription:
+      currentLanguage === 'bs'
+        ? 'Administracija korisnika i poruka na Web Fokus sajtu.'
+        : 'Administration area for managing users and messages on the Web Fokus site.',
+    ogImage: 'https://webfokus.ba/logo.png',
+    ogUrl: 'https://webfokus.ba/admin',
+    canonical: 'https://webfokus.ba/admin',
+    lang: currentLanguage
+  });
 
   useEffect(() => {
     if (!loading && !user) {
@@ -37,9 +64,9 @@ const AdminPage = () => {
 
   if (loading || !user) {
     return (
-      <div className="min-h-screen bg-background p-8">
+      <main className="min-h-screen bg-background p-8">
         <div className="max-w-4xl mx-auto">
-          <div className="flex items-center gap-4 mb-8">
+          <header className="flex items-center gap-4 mb-8">
             <Link to="/">
               <Button variant="outline" size="sm">
                 <ArrowLeft className="h-4 w-4 mr-2" />
@@ -47,19 +74,19 @@ const AdminPage = () => {
               </Button>
             </Link>
             <h1 className="text-3xl font-bold">Admin Dashboard</h1>
-          </div>
+          </header>
           <div className="text-center py-8">
             <p className="text-muted-foreground">Loading...</p>
           </div>
         </div>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <main className="min-h-screen bg-background p-8">
       <div className="max-w-4xl mx-auto">
-        <div className="flex items-center gap-4 mb-8">
+        <header className="flex items-center gap-4 mb-8">
           <Link to="/">
             <Button variant="outline" size="sm">
               <ArrowLeft className="h-4 w-4 mr-2" />
@@ -72,11 +99,11 @@ const AdminPage = () => {
               Logout
             </Button>
           </div>
-        </div>
+        </header>
 
-        <div className="mb-6">
+        <section className="mb-6">
           <h2 className="text-xl font-semibold mb-4">Registered Users</h2>
-        </div>
+        </section>
 
         {isLoading ? (
           <Card>
@@ -108,7 +135,7 @@ const AdminPage = () => {
           </div>
         )}
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -7,6 +7,8 @@ import { Label } from '@/components/ui/label';
 import { Eye, EyeOff, ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
+import { useSEO } from '@/hooks/useSEO';
+import { useTranslation } from '@/hooks/useTranslation';
 
 const API_URL = `${import.meta.env.VITE_API_URL}/users`;
 
@@ -20,6 +22,31 @@ const LoginPage = () => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const navigate = useNavigate();
   const { user, loading } = useAuth();
+  const { currentLanguage } = useTranslation();
+
+  useSEO({
+    title:
+      currentLanguage === 'bs'
+        ? 'Prijava u admin panel | Web Fokus'
+        : 'Admin Login | Web Fokus',
+    description:
+      currentLanguage === 'bs'
+        ? 'Pristupite administraciji sajta Web Fokus.'
+        : 'Sign in to manage the Web Fokus website.',
+    keywords: 'web fokus login,admin',
+    ogTitle:
+      currentLanguage === 'bs'
+        ? 'Prijava u admin panel | Web Fokus'
+        : 'Admin Login | Web Fokus',
+    ogDescription:
+      currentLanguage === 'bs'
+        ? 'Pristupite administraciji sajta Web Fokus.'
+        : 'Sign in to manage the Web Fokus website.',
+    ogImage: 'https://webfokus.ba/logo.png',
+    ogUrl: 'https://webfokus.ba/login',
+    canonical: 'https://webfokus.ba/login',
+    lang: currentLanguage
+  });
 
   useEffect(() => {
     if (!loading && user) {
@@ -98,14 +125,14 @@ const LoginPage = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
+      <main className="min-h-screen flex items-center justify-center bg-background">
         <p className="text-muted-foreground">Loading...</p>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+    <main className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md">
         <div className="mb-6">
           <Link to="/">
@@ -194,7 +221,7 @@ const LoginPage = () => {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/src/pages/PristiglePoruke.tsx
+++ b/src/pages/PristiglePoruke.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { useSEO } from '@/hooks/useSEO';
+import { useTranslation } from '@/hooks/useTranslation';
 
 interface ContactMessage {
   id: number;
@@ -19,10 +21,35 @@ const PORUKE_PASSWORD = import.meta.env.VITE_PORUKE_PASSWORD as string;
 
 const PristiglePoruke = () => {
   const navigate = useNavigate();
+  const { currentLanguage } = useTranslation();
   const [authorized, setAuthorized] = useState(false);
   const [messages, setMessages] = useState<ContactMessage[]>([]);
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+
+  useSEO({
+    title:
+      currentLanguage === 'bs'
+        ? 'Pristigle poruke | Web Fokus'
+        : 'Inbox Messages | Web Fokus',
+    description:
+      currentLanguage === 'bs'
+        ? 'Pogledajte kontakt poruke pristigle putem sajta.'
+        : 'View contact form messages received through the website.',
+    keywords: 'kontakt poruke,web fokus',
+    ogTitle:
+      currentLanguage === 'bs'
+        ? 'Pristigle poruke | Web Fokus'
+        : 'Inbox Messages | Web Fokus',
+    ogDescription:
+      currentLanguage === 'bs'
+        ? 'Pogledajte kontakt poruke pristigle putem sajta.'
+        : 'View contact form messages received through the website.',
+    ogImage: 'https://webfokus.ba/logo.png',
+    ogUrl: 'https://webfokus.ba/pristigleporuke',
+    canonical: 'https://webfokus.ba/pristigleporuke',
+    lang: currentLanguage
+  });
 
   useEffect(() => {
     if (!authorized) return;
@@ -41,7 +68,7 @@ const PristiglePoruke = () => {
 
   if (!authorized) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
+      <main className="min-h-screen flex items-center justify-center bg-background">
         <Card className="w-full max-w-sm">
           <CardHeader>
             <CardTitle>Zaštićena stranica</CardTitle>
@@ -71,12 +98,12 @@ const PristiglePoruke = () => {
             </form>
           </CardContent>
         </Card>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <main className="min-h-screen bg-background p-8">
       <div className="max-w-4xl mx-auto">
         <Card>
           <CardHeader>
@@ -112,7 +139,7 @@ const PristiglePoruke = () => {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </main>
   );
 };
 


### PR DESCRIPTION
## Summary
- inject hreflang links in `index.html`
- extend `useSEO` with OG/Twitter URL support
- optimize portfolio image `alt` text
- improve screenshots alt text in portfolio modal
- add SEO metadata for admin, login and inbox pages
- add semantic `<main>`/`<header>` wrappers
- provide placeholder `sitemap.xml`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684075d0d448832c9007928d9e86449d