### PR TITLE
Improve homepage styling

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -11,16 +11,16 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 const Contact = () => {
   const { currentLanguage, t } = useTranslation();
-  const { formData, errors, handleChange, handleSubmit, isSubmitting, isFormValid } = useContactForm();
+  const { formData, errors, handleChange, handleSubmit, isSubmitting, isFormValid, submitSuccess } = useContactForm();
 
   return (
-    <section id="contact" className="py-16 bg-muted/30">
+    <section id="contact" className="py-20 bg-muted/30">
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold mb-4">
             {t('contact_title')}
           </h2>
-          <p className="text-muted-foreground max-w-2xl mx-auto">
+          <p className="text-muted-foreground max-w-2xl mx-auto leading-relaxed">
             {t('contact_subtitle')}
           </p>
         </div>
@@ -75,7 +75,7 @@ const Contact = () => {
             </CardHeader>
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="space-y-2">
+                <div className={`space-y-3 ${errors.name ? 'bg-red-50 dark:bg-red-900/20 p-2 rounded-md' : ''}`}>
                   <Label htmlFor="name">{t('contact_form_name')} *</Label>
                   <Input
                     id="name"
@@ -94,7 +94,7 @@ const Contact = () => {
                   )}
                 </div>
 
-                <div className="space-y-2">
+                <div className={`space-y-3 ${errors.email ? 'bg-red-50 dark:bg-red-900/20 p-2 rounded-md' : ''}`}>
                   <Label htmlFor="email">{t('contact_form_email')}</Label>
                   <Input
                     id="email"
@@ -112,7 +112,7 @@ const Contact = () => {
                   )}
                 </div>
 
-                <div className="space-y-2">
+                <div className={`space-y-3 ${errors.phone ? 'bg-red-50 dark:bg-red-900/20 p-2 rounded-md' : ''}`}>
                   <Label htmlFor="phone">{t('contact_form_phone')} *</Label>
                   <Input
                     id="phone"
@@ -131,7 +131,7 @@ const Contact = () => {
                   )}
                 </div>
 
-                <div className="space-y-2">
+                <div className={`space-y-3 ${errors.message ? 'bg-red-50 dark:bg-red-900/20 p-2 rounded-md' : ''}`}>
                   <Label htmlFor="message">{t('contact_form_message')} *</Label>
                   <Textarea
                     id="message"
@@ -162,6 +162,14 @@ const Contact = () => {
                   <Send className="h-4 w-4 mr-2" />
                   {isSubmitting ? t('contact_form_sending') : t('contact_form_send')}
                 </Button>
+
+                {submitSuccess && (
+                  <p className="text-sm text-green-600 dark:text-green-400 text-center">
+                    {currentLanguage === 'bs'
+                      ? 'Poruka poslana! Javit ćemo se uskoro.'
+                      : 'Message sent! We will contact you soon.'}
+                  </p>
+                )}
 
                 <p className="text-xs text-muted-foreground text-center">
                   {currentLanguage === 'bs' 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -53,7 +53,7 @@ const Header = () => {
   ];
 
   return (
-    <header className="fixed top-0 left-0 right-0 bg-background/80 backdrop-blur-sm border-b border-border z-50">
+    <header className="fixed top-0 left-0 right-0 bg-background/80 backdrop-blur-sm border-b border-border shadow-md z-50">
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
@@ -71,15 +71,19 @@ const Header = () => {
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-6">
             {navItems.map((item) => (
-              <button
+              <a
                 key={item.key}
-                onClick={() => scrollToSection(item.key)}
-                className={`nav-link transition-colors hover:text-primary ${
+                href={`#${item.key}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection(item.key);
+                }}
+                className={`nav-link py-2 transition-colors hover:text-primary ${
                   activeSection === item.key ? 'active-link text-primary' : ''
                 }`}
               >
                 {item.label}
-              </button>
+              </a>
             ))}
           </nav>
 
@@ -111,10 +115,14 @@ const Header = () => {
               variant="ghost"
               size="icon"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
-              className="md:hidden"
+              className="md:hidden transition-transform"
               aria-label="Toggle menu"
             >
-              {isMenuOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+              {isMenuOpen ? (
+                <X className="h-4 w-4 transform rotate-90 transition-transform" />
+              ) : (
+                <Menu className="h-4 w-4 transition-transform" />
+              )}
             </Button>
           </div>
         </div>
@@ -124,15 +132,19 @@ const Header = () => {
           <nav className="nav-menu md:hidden mt-4 pb-4 border-t border-border">
             <div className="flex flex-col space-y-4 pt-4">
               {navItems.map((item) => (
-                <button
+                <a
                   key={item.key}
-                  onClick={() => scrollToSection(item.key)}
-                  className={`nav-link text-left transition-colors hover:text-primary ${
+                  href={`#${item.key}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    scrollToSection(item.key);
+                  }}
+                  className={`nav-link text-left py-2 transition-colors hover:text-primary ${
                     activeSection === item.key ? 'active-link text-primary' : ''
                   }`}
                 >
                   {item.label}
-                </button>
+                </a>
               ))}
             </div>
           </nav>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -25,14 +25,14 @@ const Hero = () => {
       className="relative min-h-screen flex items-center justify-center pt-20 bg-center bg-no-repeat bg-cover"
       style={{ backgroundImage: "url('/hero_image.webp')" }}
     >
-      {/* Stronger overlay for better text contrast */}
-      <div className="absolute inset-0 bg-black/60 dark:bg-black/70 backdrop-blur-sm pointer-events-none"></div>
+      {/* Subtle overlay for better image visibility */}
+      <div className="absolute inset-0 bg-black/50 dark:bg-black/60 backdrop-blur-sm pointer-events-none"></div>
       <div className="container mx-auto px-4 text-center relative z-10">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-6xl font-extrabold mb-6 text-white drop-shadow-lg">
+          <h1 className="text-3xl sm:text-5xl md:text-6xl font-extrabold mb-6 text-white drop-shadow-lg leading-tight">
             {t('hero_title')}
           </h1>
-          <p className="text-xl md:text-2xl text-white/90 dark:text-white/80 mb-8 max-w-2xl mx-auto drop-shadow">
+          <p className="text-xl md:text-2xl text-white/90 dark:text-white/80 mb-8 max-w-2xl mx-auto drop-shadow leading-relaxed">
             {currentLanguage === "bs" ? (
               <>
                 Vi se fokusirate na posao, mi na vaš web.
@@ -56,7 +56,7 @@ const Hero = () => {
               {t('hero_cta')}
             </Button>
             <Button
-              variant="outline"
+              variant="secondary"
               size="lg"
               onClick={scrollToPortfolio}
               className="btn bg-white/80 dark:bg-white/10 text-gray-900 dark:text-white font-semibold rounded-lg shadow-lg border border-gray-300 dark:border-white/20"

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -8,43 +8,43 @@ const Services = () => {
 
   const services = [
     {
-      icon: <Palette className="h-8 w-8 text-pink-500" />,
+      icon: <Palette className="h-8 w-8 text-purple-600" />,
       title: t('service_design_title'),
       description: t('service_design_desc'),
       details: t('service_design_details'), // Dodaj detalje u prevodima
     },
     {
-      icon: <Search className="h-8 w-8 text-blue-500" />,
+      icon: <Search className="h-8 w-8 text-purple-600" />,
       title: t('service_seo_title'),
       description: t('service_seo_desc'),
       details: t('service_seo_details'),
     },
     {
-      icon: <Globe className="h-8 w-8 text-green-500" />,
+      icon: <Globe className="h-8 w-8 text-purple-600" />,
       title: t('service_multilang_title'),
       description: t('service_multilang_desc'),
       details: t('service_multilang_details'),
     },
     {
-      icon: <Server className="h-8 w-8 text-purple-500" />,
+      icon: <Server className="h-8 w-8 text-purple-600" />,
       title: t('service_hosting_title'),
       description: t('service_hosting_desc'),
       details: t('service_hosting_details'),
     },
     {
-      icon: <Moon className="h-8 w-8 text-indigo-500" />,
+      icon: <Moon className="h-8 w-8 text-purple-600" />,
       title: t('service_themes_title'),
       description: t('service_themes_desc'),
       details: t('service_themes_details'),
     },
     {
-      icon: <Zap className="h-8 w-8 text-yellow-500" />,
+      icon: <Zap className="h-8 w-8 text-purple-600" />,
       title: t('service_speed_title'),
       description: t('service_speed_desc'),
       details: t('service_speed_details'),
     },
     {
-      icon: <Wrench className="h-8 w-8 text-gray-500" />,
+      icon: <Wrench className="h-8 w-8 text-purple-600" />,
       title: t('service_maintenance_title'),
       description: t('service_maintenance_desc'),
       details: t('service_maintenance_details'),

--- a/src/hooks/useContactForm.ts
+++ b/src/hooks/useContactForm.ts
@@ -14,6 +14,7 @@ export const useContactForm = () => {
     message: ''
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
   const [errors, setErrors] = useState<Partial<Record<keyof ContactFormData, string>>>({});
 
   const validateField = (name: keyof ContactFormData, value: string) => {
@@ -86,6 +87,8 @@ export const useContactForm = () => {
       }
 
       toast.success('Poruka je uspješno poslana! Kontaktiraćemo vas uskoro.');
+      setSubmitSuccess(true);
+      setTimeout(() => setSubmitSuccess(false), 5000);
       setFormData({
         name: '',
         email: '',
@@ -115,6 +118,7 @@ export const useContactForm = () => {
     handleSubmit,
     isSubmitting,
     hasErrors,
-    isFormValid
+    isFormValid,
+    submitSuccess
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -49,7 +49,7 @@
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
 
-    --card: 222.2 84% 4.9%;
+    --card: 217.2 32.6% 12%;
     --card-foreground: 210 40% 98%;
 
     --popover: 222.2 84% 4.9%;


### PR DESCRIPTION
## Summary
- refine hero typography, overlay, and buttons
- convert navbar items to links, add drop shadow and animated toggle
- polish contact form spacing and success feedback
- use consistent purple accent for service icons
- lighten dark mode card background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d8849bc0832c9858902d0d0f776b