### PR TITLE
Update homepage bilingual copy

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -67,14 +67,19 @@ const Contact = () => {
 
           {/* Contact Form */}
           <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Send className="h-5 w-5 text-primary" />
-                {t('contact_form_title')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleSubmit} className="space-y-4">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Send className="h-5 w-5 text-primary" />
+              {t('contact_form_title')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground mb-4">
+              {currentLanguage === 'bs'
+                ? 'Imaš ideju? Pošalji poruku i javi nam se!'
+                : 'Have an idea? Send us a message!'}
+            </p>
+            <form onSubmit={handleSubmit} className="space-y-4">
                 <div className={`space-y-3 ${errors.name ? 'bg-red-50 dark:bg-red-900/20 p-2 rounded-md' : ''}`}>
                   <Label htmlFor="name">{t('contact_form_name')} *</Label>
                   <Input

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 
 const Footer = () => {
-  const { t } = useTranslation();
+  const { t, currentLanguage } = useTranslation();
 
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
@@ -21,6 +21,11 @@ const Footer = () => {
             <h3 className="text-2xl font-bold text-primary mb-4">Web Fokus</h3>
             <p className="text-muted-foreground mb-4">
               {t('footer_tagline')}
+            </p>
+            <p className="text-muted-foreground mb-4">
+              {currentLanguage === 'bs'
+                ? 'Izrada web stranica sa jasnim ciljem – rast vašeg biznisa.'
+                : 'Web design with one clear goal – helping your business grow.'}
             </p>
           </div>
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -30,20 +30,22 @@ const Hero = () => {
       <div className="container mx-auto px-4 text-center relative z-10">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-3xl sm:text-5xl md:text-6xl font-extrabold mb-6 text-white drop-shadow-lg leading-tight">
-            {t('hero_title')}
+            {currentLanguage === 'bs'
+              ? 'Profesionalna izrada web stranica za rast poslovanja'
+              : 'Professional website design to grow your business'}
           </h1>
           <p className="text-xl md:text-2xl text-white/90 dark:text-white/80 mb-8 max-w-2xl mx-auto drop-shadow leading-relaxed">
-            {currentLanguage === "bs" ? (
+            {currentLanguage === 'bs' ? (
               <>
-                Vi se fokusirate na posao, mi na vaš web.
+                Posvetite se svom poslu, a nama prepustite izradu web stranica.
                 <br className="hidden md:inline" />
-                Moderna, responzivna web rješenja već od 250 KM.
+                Moderna i responzivna rješenja po pristupačnim cijenama.
               </>
             ) : (
               <>
-                You focus on business, we focus on your web.
+                Focus on your business and let us handle website development.
                 <br className="hidden md:inline" />
-                Modern, responsive web solutions from 250 KM.
+                Modern, responsive solutions at affordable prices.
               </>
             )}
           </p>
@@ -53,7 +55,7 @@ const Hero = () => {
               onClick={scrollToContact}
               className="btn bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-semibold rounded-lg shadow-lg"
             >
-              {t('hero_cta')}
+              {currentLanguage === 'bs' ? 'Zatraži ponudu' : 'Get a quote'}
             </Button>
             <Button
               variant="secondary"
@@ -61,7 +63,7 @@ const Hero = () => {
               onClick={scrollToPortfolio}
               className="btn bg-white/80 dark:bg-white/10 text-gray-900 dark:text-white font-semibold rounded-lg shadow-lg border border-gray-300 dark:border-white/20"
             >
-              {t('hero_portfolio')}
+              {currentLanguage === 'bs' ? 'Pogledaj primjere' : 'See examples'}
             </Button>
           </div>
         </div>

--- a/src/components/PortfolioOptimized.tsx
+++ b/src/components/PortfolioOptimized.tsx
@@ -73,9 +73,9 @@ const PortfolioOptimized = () => {
             {t('portfolio_title') || (currentLanguage === 'bs' ? 'Naši Projekti' : 'Our Projects')}
           </h2>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            {currentLanguage === 'bs' 
-              ? 'Pogledajte neke od naših najuspješnijih web projekata'
-              : 'Check out some of our most successful web projects'}
+            {currentLanguage === 'bs'
+              ? 'Pogledajte primjere naših projekata i uvjerite se u kvalitetu'
+              : 'See examples of our work and explore our quality'}
           </p>
         </div>
 

--- a/src/components/PricingOptimized.tsx
+++ b/src/components/PricingOptimized.tsx
@@ -10,85 +10,73 @@ const PricingOptimized = () => {
   const plans = [
     {
       id: 'basic',
-      name: currentLanguage === 'bs' ? 'Osnovni' : 'Basic',
+      name: currentLanguage === 'bs' ? 'Osnovni paket' : 'Basic Plan',
       price: '250',
-      description: currentLanguage === 'bs' 
-        ? 'Savršen za mala preduzeća koja tek počinju'
+      description: currentLanguage === 'bs'
+        ? 'Savršen za mali biznis koji tek kreće online'
         : 'Perfect for small businesses just getting started',
       icon: <Star className="h-6 w-6" />,
-      features: currentLanguage === 'bs' ? [
-        'Do 5 stranica',
-        'Responzivan dizajn',
-        'Kontakt forma',
-        'Google Maps integracija',
-        'SSL sertifikat',
-        '1 godina hosting'
-      ] : [
-        'Up to 5 pages',
-        'Responsive design',
-        'Contact form',
-        'Google Maps integration',
-        'SSL certificate',
-        '1 year hosting'
-      ],
+      features: currentLanguage === 'bs'
+        ? [
+            'Do 3 stranice',
+            'Bez kontakt forme',
+            'Responsive dizajn',
+            'SEO osnovna optimizacija'
+          ]
+        : [
+            'Up to 3 pages',
+            'No contact form',
+            'Responsive design',
+            'Basic SEO'
+          ],
       popular: false
     },
     {
       id: 'pro',
-      name: currentLanguage === 'bs' ? 'Profesionalni' : 'Professional',
+      name: currentLanguage === 'bs' ? 'Profesionalni paket' : 'Professional Plan',
       price: '450',
       description: currentLanguage === 'bs'
-        ? 'Idealan za rastući biznis sa više funkcionalnosti'
-        : 'Ideal for growing businesses with more functionality',
+        ? 'Idealan za rastući biznis kojem treba više funkcionalnosti'
+        : 'Ideal for growing businesses needing more features',
       icon: <Zap className="h-6 w-6" />,
-      features: currentLanguage === 'bs' ? [
-        'Do 15 stranica',
-        'Responzivan dizajn',
-        'CMS sistem',
-        'SEO optimizacija',
-        'Google Analytics',
-        'Email marketing integracija',
-        'Chat podrška',
-        '1 godina hosting + domena'
-      ] : [
-        'Up to 15 pages',
-        'Responsive design',
-        'CMS system',
-        'SEO optimization',
-        'Google Analytics',
-        'Email marketing integration',
-        'Chat support',
-        '1 year hosting + domain'
-      ],
+      features: currentLanguage === 'bs'
+        ? [
+            'Sve iz Osnovnog paketa',
+            'Do 7 stranica',
+            'Kontakt forma',
+            'Galerija slika',
+            'Dvojezičnost'
+          ]
+        : [
+            'Includes everything from Basic Plan',
+            'Up to 7 pages',
+            'Contact form',
+            'Image gallery',
+            'Multilingual support'
+          ],
       popular: true
     },
     {
       id: 'premium',
-      name: currentLanguage === 'bs' ? 'Premium' : 'Premium',
+      name: currentLanguage === 'bs' ? 'Premium paket' : 'Premium Plan',
       price: '750',
       description: currentLanguage === 'bs'
         ? 'Kompletno rješenje za ozbiljan online biznis'
         : 'Complete solution for serious online business',
       icon: <Crown className="h-6 w-6" />,
-      features: currentLanguage === 'bs' ? [
-        'Neograničeno stranica',
-        'E-commerce funkcionalnost',
-        'Napredna SEO optimizacija',
-        'Analitika i izvještaji',
-        'Rezervacije online',
-        'Višejezična podrška',
-        'Premium podrška 24/7',
-        '2 godine hosting + domena'
-      ] : [
-        'Unlimited pages',
-        'E-commerce functionality',
-        'Advanced SEO optimization',
-        'Analytics and reports',
-        'Online booking system',
-        'Multi-language support',
-        'Premium 24/7 support',
-        '2 years hosting + domain'
-      ],
+      features: currentLanguage === 'bs'
+        ? [
+            'Sve iz Profesionalnog paketa',
+            'Hosting i domena 1 godina',
+            'Prioritetna podrška',
+            'Izmjene do 30 dana'
+          ]
+        : [
+            'Includes everything from Professional Plan',
+            '1 year domain & hosting',
+            'Priority support',
+            'Revisions up to 30 days'
+          ],
       popular: false
     }
   ];
@@ -182,7 +170,12 @@ const PricingOptimized = () => {
           ))}
         </div>
 
-        <div className="text-center mt-12">
+        <div className="text-center mt-12 space-y-2">
+          <p className="font-semibold">
+            {currentLanguage === 'bs'
+              ? 'Akcijske cijene! Važe do 30.06.'
+              : 'Promo prices! Valid until June 30th.'}
+          </p>
           <p className="text-muted-foreground">
             {currentLanguage === 'bs'
               ? 'Trebate nešto specifično? Kontaktirajte nas za prilagođenu ponudu.'

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -3,28 +3,52 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { MessageCircle, Palette, Code, Rocket } from "lucide-react";
 
 const Process = () => {
-  const { t } = useTranslation();
+  const { currentLanguage, t } = useTranslation();
 
   const steps = [
     {
-      icon: <MessageCircle className="h-8 w-8 text-blue-500" />, // Plava
-      title: t('process_step1_title'),
-      description: t('process_step1_desc')
+      icon: <MessageCircle className="h-8 w-8 text-blue-500" />,
+      title:
+        currentLanguage === 'bs'
+          ? 'Korak 1: Kontaktirajte nas'
+          : 'Step 1: Get in touch',
+      description:
+        currentLanguage === 'bs'
+          ? 'Pošaljite nam osnovne informacije i brzo odgovaramo na sve upite.'
+          : 'Send us your basic info and we will reply quickly to all inquiries.'
     },
     {
-      icon: <Palette className="h-8 w-8 text-pink-500" />, // Roza
-      title: t('process_step2_title'),
-      description: t('process_step2_desc')
+      icon: <Palette className="h-8 w-8 text-pink-500" />,
+      title:
+        currentLanguage === 'bs'
+          ? 'Korak 2: Dogovor dizajna'
+          : 'Step 2: Plan the design',
+      description:
+        currentLanguage === 'bs'
+          ? 'Zajedno određujemo izgled i funkcionalnosti koje želite na sajtu.'
+          : 'Together we define the look and features you want on the site.'
     },
     {
-      icon: <Code className="h-8 w-8 text-purple-500" />, // Ljubičasta
-      title: t('process_step3_title'),
-      description: t('process_step3_desc')
+      icon: <Code className="h-8 w-8 text-purple-500" />,
+      title:
+        currentLanguage === 'bs'
+          ? 'Korak 3: Izrada'
+          : 'Step 3: Development',
+      description:
+        currentLanguage === 'bs'
+          ? 'Izrađujemo stranicu modernim alatima i prilagođavamo je svim uređajima.'
+          : 'We build the site with modern tools and optimize it for all devices.'
     },
     {
-      icon: <Rocket className="h-8 w-8 text-green-500" />, // Zelena
-      title: t('process_step4_title'),
-      description: t('process_step4_desc')
+      icon: <Rocket className="h-8 w-8 text-green-500" />,
+      title:
+        currentLanguage === 'bs'
+          ? 'Korak 4: Isporuka i podrška'
+          : 'Step 4: Delivery & support',
+      description:
+        currentLanguage === 'bs'
+          ? 'Dobijate gotov sajt uz kratko uputstvo i dostupnu podršku za pitanja.'
+          : 'You receive the finished site with a quick guide and ongoing support.'
     }
   ];
 

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -8,46 +8,52 @@ const Services = () => {
 
   const services = [
     {
-      icon: <Palette className="h-8 w-8 text-purple-600" />,
-      title: t('service_design_title'),
-      description: t('service_design_desc'),
-      details: t('service_design_details'), // Dodaj detalje u prevodima
+      icon: <Zap className="h-8 w-8 text-purple-600" />,
+      title: currentLanguage === 'bs' ? 'Brza izrada' : 'Fast delivery',
+      description:
+        currentLanguage === 'bs'
+          ? 'Vaš sajt je online za samo nekoliko dana bez kompromisa na kvalitetu.'
+          : 'Your site goes live in just a few days with no compromise on quality.',
+      details:
+        currentLanguage === 'bs'
+          ? 'Vaš sajt je online za samo nekoliko dana bez kompromisa na kvalitetu.'
+          : 'Your site goes live in just a few days with no compromise on quality.'
     },
     {
       icon: <Search className="h-8 w-8 text-purple-600" />,
-      title: t('service_seo_title'),
-      description: t('service_seo_desc'),
-      details: t('service_seo_details'),
+      title: currentLanguage === 'bs' ? 'SEO optimizacija' : 'SEO optimization',
+      description:
+        currentLanguage === 'bs'
+          ? 'Osnovna SEO podešavanja pomažu da budete primijećeni na Googleu i dođete do više klijenata.'
+          : 'Basic SEO settings help you get noticed on Google and reach more clients.',
+      details:
+        currentLanguage === 'bs'
+          ? 'Osnovna SEO podešavanja pomažu da budete primijećeni na Googleu i dođete do više klijenata.'
+          : 'Basic SEO settings help you get noticed on Google and reach more clients.'
     },
     {
       icon: <Globe className="h-8 w-8 text-purple-600" />,
-      title: t('service_multilang_title'),
-      description: t('service_multilang_desc'),
-      details: t('service_multilang_details'),
-    },
-    {
-      icon: <Server className="h-8 w-8 text-purple-600" />,
-      title: t('service_hosting_title'),
-      description: t('service_hosting_desc'),
-      details: t('service_hosting_details'),
-    },
-    {
-      icon: <Moon className="h-8 w-8 text-purple-600" />,
-      title: t('service_themes_title'),
-      description: t('service_themes_desc'),
-      details: t('service_themes_details'),
-    },
-    {
-      icon: <Zap className="h-8 w-8 text-purple-600" />,
-      title: t('service_speed_title'),
-      description: t('service_speed_desc'),
-      details: t('service_speed_details'),
+      title: currentLanguage === 'bs' ? 'Dvojezični sadržaj' : 'Bilingual content',
+      description:
+        currentLanguage === 'bs'
+          ? 'Bosanski i engleski jezik uključeni standardno kako biste dosegli širu publiku.'
+          : 'Bosnian and English included as standard so you can reach a wider audience.',
+      details:
+        currentLanguage === 'bs'
+          ? 'Bosanski i engleski jezik uključeni standardno kako biste dosegli širu publiku.'
+          : 'Bosnian and English included as standard so you can reach a wider audience.'
     },
     {
       icon: <Wrench className="h-8 w-8 text-purple-600" />,
-      title: t('service_maintenance_title'),
-      description: t('service_maintenance_desc'),
-      details: t('service_maintenance_details'),
+      title: currentLanguage === 'bs' ? 'Podrška i održavanje' : 'Support & maintenance',
+      description:
+        currentLanguage === 'bs'
+          ? 'Nudimo pomoć i manje izmjene i nakon isporuke kako bi vaš sajt ostao ažuran.'
+          : 'We provide help and minor changes after delivery so your site stays up to date.',
+      details:
+        currentLanguage === 'bs'
+          ? 'Nudimo pomoć i manje izmjene i nakon isporuke kako bi vaš sajt ostao ažuran.'
+          : 'We provide help and minor changes after delivery so your site stays up to date.'
     }
   ];
 


### PR DESCRIPTION
## Summary
- rewrite hero intro and CTA buttons
- highlight four key service benefits
- restructure pricing plans and add promo note
- simplify process steps text
- update portfolio intro text
- add lead-in in contact form
- add closing statement in footer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68420766f81c832ca91afd5328cc92e9