### PR TITLE
Add security improvements

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.9.0",
+        "bcryptjs": "^3.0.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -112,6 +113,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "@prisma/client": "^6.9.0",
+    "bcryptjs": "^3.0.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,8 @@ const cors = require("cors");
 const compression = require("compression");
 const { PrismaClient } = require("@prisma/client");
 const dotenv = require("dotenv");
+const bcrypt = require("bcryptjs");
+const { contactFormSchema, sanitizeInput } = require("./validation");
 
 dotenv.config();
 
@@ -15,9 +17,19 @@ app.use(cors());
 app.use(express.json());
 app.use(compression());
 
+function authenticate(req, res, next) {
+  const password = req.headers["x-admin-password"];
+  if (password !== ADMIN_PASSWORD) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  next();
+}
+
+app.use("/users", authenticate);
+
 app.get("/users", async (req, res) => {
   try {
-    const users = await prisma.user.findMany();
+    const users = await prisma.user.findMany({ select: { id: true, email: true } });
     res.json(users);
   } catch (err) {
     console.error(err);
@@ -28,8 +40,9 @@ app.get("/users", async (req, res) => {
 app.post("/users", async (req, res) => {
   const { email, password } = req.body;
   try {
-    const newUser = await prisma.user.create({ data: { email, password } });
-    res.json(newUser);
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const newUser = await prisma.user.create({ data: { email, password: hashedPassword } });
+    res.json({ id: newUser.id, email: newUser.email });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "Failed to create user" });
@@ -37,10 +50,21 @@ app.post("/users", async (req, res) => {
 });
 
 app.post("/contact", async (req, res) => {
-  const { name, email, message } = req.body;
+  const { name, email, phone, message } = req.body;
   try {
+    const parsed = contactFormSchema.safeParse({ name, email, phone, message });
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid input" });
+    }
+
+    const sanitizedData = {
+      name: sanitizeInput(parsed.data.name).trim(),
+      email: parsed.data.email ? parsed.data.email.trim() : "",
+      message: sanitizeInput(parsed.data.message).trim(),
+    };
+
     const saved = await prisma.contactMessage.create({
-      data: { name, email, message },
+      data: sanitizedData,
     });
     console.log("Contact message saved:", saved);
     res.status(201).json({ success: true });

--- a/backend/validation.js
+++ b/backend/validation.js
@@ -1,0 +1,41 @@
+const { z } = require('zod');
+
+// Contact form validation schema
+const contactFormSchema = z.object({
+  name: z
+    .string()
+    .min(2, 'Name must be at least 2 characters')
+    .max(100, 'Name must be less than 100 characters')
+    .regex(/^[a-zA-ZšđčćžŠĐČĆŽ\s-']+$/, 'Name contains invalid characters'),
+  email: z.preprocess(
+    (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+    z
+      .string()
+      .email('Invalid email')
+      .max(254, 'Email too long')
+      .toLowerCase()
+      .optional()
+  ),
+  phone: z
+    .string({ required_error: 'Phone is required' })
+    .refine((val) => {
+      const phoneRegex = /^\+?[1-9]\d{0,15}$/;
+      const cleanPhone = val.replace(/[\s-()]/g, '');
+      return phoneRegex.test(cleanPhone) && cleanPhone.length >= 8 && cleanPhone.length <= 16;
+    }, 'Invalid phone number'),
+  message: z
+    .string()
+    .min(10, 'Message must be at least 10 characters')
+    .max(2000, 'Message must be less than 2000 characters')
+    .refine((val) => val.trim().length >= 10, 'Message cannot be only whitespace')
+});
+
+// Sanitization utility
+const sanitizeInput = (input) => {
+  return input
+    .replace(/[<>]/g, '') // Remove potential HTML tags
+    .replace(/javascript:/gi, '') // Remove javascript: protocol
+    .replace(/on\w+=/gi, ''); // Remove event handlers
+};
+
+module.exports = { contactFormSchema, sanitizeInput };


### PR DESCRIPTION
## Summary
- hash user passwords
- protect `/users` endpoints with header-based auth
- validate and sanitize contact data on the server
- add bcrypt dependency for hashing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849852482c4832cb9a6ea1180d6a119