### PR TITLE
Add rate limiting to contact form

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0"
+    "express-rate-limit": "^7.5.0",
   },
   "devDependencies": {
     "prisma": "^6.9.0"

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const cors = require("cors");
 const compression = require("compression");
+const rateLimit = require("express-rate-limit");
 const { PrismaClient } = require("@prisma/client");
 const dotenv = require("dotenv");
 const bcrypt = require("bcryptjs");
@@ -12,6 +13,14 @@ const prisma = new PrismaClient();
 const app = express();
 const PORT = process.env.PORT || 3001;
 const ADMIN_PASSWORD = process.env.ADMIN_ACCESS_PASSWORD;
+
+const contactLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
 
 app.use(cors());
 app.use(express.json());
@@ -49,7 +58,7 @@ app.post("/users", async (req, res) => {
   }
 });
 
-app.post("/contact", async (req, res) => {
+app.post("/contact", contactLimiter, async (req, res) => {
   const { name, email, phone, message } = req.body;
   try {
     const parsed = contactFormSchema.safeParse({ name, email, phone, message });

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "dotenv": "^16.5.0",
         "embla-carousel-react": "^8.3.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -5077,6 +5078,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "dotenv": "^16.5.0",
     "embla-carousel-react": "^8.3.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",


### PR DESCRIPTION
## Summary
- protect POST `/contact` with `express-rate-limit`
- add `express-rate-limit` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849eeb3dc64832cbad9241dff0801a5