### PR TITLE
Restrict CORS via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 VITE_API_URL=http://localhost:3001
 ADMIN_ACCESS_PASSWORD=CHANGE_ME
+PRODUCTION_DOMAIN=https://example.com
 
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Create a `.env` file based on `.env.example` and set the variables:
 
 - `VITE_API_URL` - base URL of the backend API
 - `ADMIN_ACCESS_PASSWORD` - password for accessing `/pristigleporuke`
+- `PRODUCTION_DOMAIN` - domain allowed by the backend CORS policy
 
 ```bash
 cp .env.example .env

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,7 @@ const prisma = new PrismaClient();
 const app = express();
 const PORT = process.env.PORT || 3001;
 const ADMIN_PASSWORD = process.env.ADMIN_ACCESS_PASSWORD;
+const ALLOWED_ORIGIN = process.env.PRODUCTION_DOMAIN;
 
 const contactLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -22,7 +23,11 @@ const contactLimiter = rateLimit({
   message: { error: "Too many requests, please try again later." },
 });
 
-app.use(cors());
+app.use(
+  cors({
+    origin: ALLOWED_ORIGIN,
+  })
+);
 app.use(express.json());
 app.use(compression());
 


### PR DESCRIPTION
## Summary
- restrict API CORS to a single domain defined via `PRODUCTION_DOMAIN`
- document the new environment variable
- update example `.env` with `PRODUCTION_DOMAIN`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849effcc02c832ca50fc4b9bd67f4db