### PR TITLE
Add helmet middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,9 @@
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
+        "helmet": "^8.1.0"
       },
       "devDependencies": {
         "prisma": "^6.9.0"
@@ -442,6 +444,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -557,6 +574,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,8 +16,9 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
+    "helmet": "^8.1.0"
   },
   "devDependencies": {
     "prisma": "^6.9.0"

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const cors = require("cors");
 const compression = require("compression");
 const rateLimit = require("express-rate-limit");
+const helmet = require("helmet");
 const { PrismaClient } = require("@prisma/client");
 const dotenv = require("dotenv");
 const bcrypt = require("bcryptjs");
@@ -30,6 +31,7 @@ app.use(
 );
 app.use(express.json());
 app.use(compression());
+app.use(helmet());
 
 function authenticate(req, res, next) {
   const password = req.headers["x-admin-password"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "embla-carousel-react": "^8.3.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
+        "helmet": "^8.1.0",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -5496,6 +5497,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "embla-carousel-react": "^8.3.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
+    "helmet": "^8.1.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",


### PR DESCRIPTION
## Summary
- add Helmet to dependencies
- enable Helmet in backend server to set security headers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849f1dd1194832c94ea339df830fc5d