### PR TITLE
Optimize bundle by lazy-loading contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     
     <!-- Google Analytics 4 -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
+    <script async defer src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,5 +1,4 @@
 
-import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/components/FAQOptimized.tsx
+++ b/src/components/FAQOptimized.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import { ChevronDown } from "lucide-react";
 

--- a/src/components/FadeInSection.jsx
+++ b/src/components/FadeInSection.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 const FadeInSection = ({ children, className = '' }) => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,4 @@
 
-import React from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 
 const Footer = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTheme } from "@/hooks/useTheme";

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/hooks/useTranslation";
 

--- a/src/components/PortfolioModal.tsx
+++ b/src/components/PortfolioModal.tsx
@@ -1,5 +1,4 @@
 
-import React from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import { X, ExternalLink, Monitor, Smartphone, Code } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/PortfolioOptimized.tsx
+++ b/src/components/PortfolioOptimized.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, lazy, Suspense } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import { ExternalLink, Code, Smartphone, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/PricingOptimized.tsx
+++ b/src/components/PricingOptimized.tsx
@@ -1,5 +1,4 @@
 
-import React from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import { Check, Star, Zap, Crown } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import { MessageCircle, Palette, Code, Rocket } from "lucide-react";
 

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import { Star, ChevronLeft, ChevronRight, User, Quote } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from "@/hooks/useTranslation";
 import {
   Palette,

--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import bsTranslations from '@/lang/bs.json';
 import enTranslations from '@/lang/en.json';
 

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/src/pages/WebFokusHome.tsx
+++ b/src/pages/WebFokusHome.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect } from 'react';
+import { useEffect, lazy, Suspense } from 'react';
 import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
@@ -8,7 +8,7 @@ import Process from "@/components/Process";
 import PricingOptimized from "@/components/PricingOptimized";
 import Reviews from "@/components/Reviews";
 import FAQOptimized from "@/components/FAQOptimized";
-import Contact from "@/components/Contact";
+const Contact = lazy(() => import("@/components/Contact"));
 import Footer from "@/components/Footer";
 import { useTheme } from "@/hooks/useTheme";
 import { useSEO } from "@/hooks/useSEO";
@@ -78,7 +78,9 @@ const WebFokusHome = () => {
         <PricingOptimized />
         <Reviews />
         <FAQOptimized />
-        <Contact />
+        <Suspense fallback={<div className="py-12 text-center">Loading...</div>}>
+          <Contact />
+        </Suspense>
       </main>
       <Footer />
       


### PR DESCRIPTION
## Summary
- defer GA script loading
- lazy load the contact form component
- drop unused React default imports for better tree shaking

## Testing
- `npm run lint`
- `npm test` *(fails: Prisma client not generated)*

------
https://chatgpt.com/codex/tasks/task_e_684c5254466c832cab6f9caac736f234